### PR TITLE
Fix the get_webhook docstring return field

### DIFF
--- a/mbed_cloud/connect.py
+++ b/mbed_cloud/connect.py
@@ -502,7 +502,7 @@ class ConnectAPI(BaseAPI):
     def get_webhook(self):
         """Get the current callback URL if it exists.
 
-        :return: void
+        :return: The currently set webhook
         """
         api = self.mds.DefaultApi()
         return Webhook(api.v2_notification_callback_get())


### PR DESCRIPTION
The ConnectAPI.get_webhook function returns a Webhook object, not void.