### PR TITLE
Fix body check in rest.py

### DIFF
--- a/mbed_cloud/_backends/connector_ca/rest.py
+++ b/mbed_cloud/_backends/connector_ca/rest.py
@@ -139,7 +139,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,

--- a/mbed_cloud/_backends/developer_certificate/rest.py
+++ b/mbed_cloud/_backends/developer_certificate/rest.py
@@ -139,7 +139,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,

--- a/mbed_cloud/_backends/device_directory/rest.py
+++ b/mbed_cloud/_backends/device_directory/rest.py
@@ -139,7 +139,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,

--- a/mbed_cloud/_backends/iam/rest.py
+++ b/mbed_cloud/_backends/iam/rest.py
@@ -139,7 +139,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,

--- a/mbed_cloud/_backends/mds/rest.py
+++ b/mbed_cloud/_backends/mds/rest.py
@@ -139,7 +139,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,

--- a/mbed_cloud/_backends/statistics/rest.py
+++ b/mbed_cloud/_backends/statistics/rest.py
@@ -139,7 +139,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,

--- a/mbed_cloud/_backends/update_service/rest.py
+++ b/mbed_cloud/_backends/update_service/rest.py
@@ -139,7 +139,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,


### PR DESCRIPTION
Checking for "trueness" here is not sufficient.  An empty list has a truth
value of false so it will not be encoded as json and sent as the request
body as it should.  Instead we need to check explicitly if body is None.

For example, an empty list is sent when deleting all presubscriptions
via update_presubscriptions.