### PR TITLE
Make mbed-cloud-sdk more broadly compatible

### DIFF
--- a/mbed_cloud/__init__.py
+++ b/mbed_cloud/__init__.py
@@ -18,15 +18,12 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import datetime
 from six import iteritems
 from six import string_types
 import sys
-import urllib.error
-import urllib.parse
-import urllib.request
+from future.moves import urllib
 
 from mbed_cloud.bootstrap import Config
 from mbed_cloud.exceptions import CloudValueError


### PR DESCRIPTION
The normal approach with aliases fails on my system. This doesn't.