### PR TITLE
Error checking for incorrect host path

### DIFF
--- a/src/mbed_cloud/__init__.py
+++ b/src/mbed_cloud/__init__.py
@@ -48,6 +48,10 @@ class BaseAPI(object):
                 sys.stderr.write("'host' config needs to use protocol HTTPS. Ignoring.\n")
                 sys.stderr.flush()
                 del config["host"]
+            elif "api" not in config["host"]:
+                sys.stderr.write("'host' config needs to point to the API hostname.. Ignoring.\n")
+                sys.stderr.flush()
+                del config["host"]
         else:
             # Host is not set. Set default host.
             config.update({'host': 'https://api.us-east-1.mbedcloud.com'})


### PR DESCRIPTION
This change ensures that when a host is specified in the command arguments, it does not cause an exception if the user does not specify the API path.

Currently, if the user specifies a host in the config object, and it does not contain a reference to 'api' (for example: https://portal-os2.mbedcloudstaging.net rather than https://api-os2.mbedcloudstaging.net), it will cause an error, like in conjunction with https://github.com/ARMmbed/mbed-cloud-sdk-python-quickstart:

```
davwal04@E108444 MINGW32 ~/Desktop/oob/CC124/mbed-cloud-sdk-python-quickstart 
$ python app.py --host https://portal-os2.mbedcloudstaging.net
INFO:root:mbed Cloud Quickstart listening at http://localhost:8080
[2017-10-26 12:17:57,926] ERROR in app: Exception on / [GET]
Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\flask\app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "C:\Python27\lib\site-packages\flask\app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "C:\Python27\lib\site-packages\flask\app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "C:\Python27\lib\site-packages\flask\app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "C:\Python27\lib\site-packages\flask\app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "app.py", line 97, in index
    for device in connectApi.list_connected_devices(filters={'device_type': {'$eq': 'default'}}):
  File "C:\Python27\lib\site-packages\mbed_cloud\decorators.py", line 33, in wrapped_f
    return fn(*args, **kwargs)
  File "C:\Python27\lib\site-packages\mbed_cloud\connect.py", line 162, in list_connected_devices
    return PaginatedResponse(api.device_list, lwrap_type=Device, **kwargs)
  File "C:\Python27\lib\site-packages\mbed_cloud\__init__.py", line 314, in __init__
    self._get_page()
  File "C:\Python27\lib\site-packages\mbed_cloud\__init__.py", line 322, in _get_page
    self._data = [self._lwrap_type(e) if self._lwrap_type else e for e in resp.data]
TypeError: 'NoneType' object is not iterable
```

With this fix, it causes a gentle reminder to include the API path and not the Portal path, and then ignores it and uses the default path:

```
davwal04@E108444 MINGW32 ~/Desktop/oob/CC124/mbed-cloud-sdk-python-quickstart
$ python app.py --host https://portal-os2.mbedcloudstaging.net
'host' config needs to point to the API hostname.. Ignoring.
'host' config needs to point to the API hostname.. Ignoring.
INFO:root:mbed Cloud Quickstart listening at http://localhost:8080
```

