### PR TITLE
Add a json serialiser

### DIFF
--- a/src/mbed_cloud/__init__.py
+++ b/src/mbed_cloud/__init__.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 
 from builtins import object
 import datetime
+import json
 from six import iteritems
 from six import string_types
 import sys
@@ -264,9 +265,25 @@ class BaseObject(object):
                 query[key] = val
         return query
 
+    def to_json(self, separators=(',', ': '), sort_keys=True, indent=4):
+        """Return all info about this object in JSON format."""
+        return json.dumps(self.to_dict(),
+                          separators=separators,
+                          sort_keys=sort_keys,
+                          indent=indent,
+                          cls=DeviceEncoder)
+
     def __repr__(self):
         """For print and pprint."""
         return str(self.to_dict())
+
+
+class DeviceEncoder(json.JSONEncoder):
+    """Add support for displaying datetime objects with this."""
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        return json.JSONEncoder.default(self, obj)
 
 
 class _FakePaginatedResponse(object):


### PR DESCRIPTION
Add a to_json function to BaseObject class so that we can
call print() on devices and see human-readable information.

Signed-off-by: mbanders <michael.anderson@arm.com>