### PR TITLE
os2 test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,12 +61,12 @@ aliases:
               if [[ ${CLOUD_VERSION} == production ]]; then
                 export MBED_CLOUD_API_HOST=${MBED_CLOUD_API_HOST_PROD};
                 export MBED_CLOUD_API_KEY=${MBED_CLOUD_API_KEY_PROD};
-                echo 'environment variables swapped: ${CLOUD_VERSION}';
+                echo "environment variables swapped: ${CLOUD_VERSION}";
               fi
               if [[ ${CLOUD_VERSION} == os2 ]]; then
                 export MBED_CLOUD_API_HOST=${MBED_CLOUD_API_HOST_OS2};
                 export MBED_CLOUD_API_KEY=${MBED_CLOUD_API_KEY_OS2};
-                echo 'environment variables swapped: ${CLOUD_VERSION}';
+                echo "environment variables swapped: ${CLOUD_VERSION}";
               fi
               echo "{\"api_key\":\"$MBED_CLOUD_API_KEY\", \"host\":\"$MBED_CLOUD_API_HOST\"}" > .mbed_cloud_config.json
               login="$(aws ecr get-login --no-include-email)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,12 @@ aliases:
               if [[ ${CLOUD_VERSION} == production ]]; then
                 export MBED_CLOUD_API_HOST=${MBED_CLOUD_API_HOST_PROD};
                 export MBED_CLOUD_API_KEY=${MBED_CLOUD_API_KEY_PROD};
-                echo 'environment variables swapped';
+                echo 'environment variables swapped: ${CLOUD_VERSION}';
+              fi
+              if [[ ${CLOUD_VERSION} == os2 ]]; then
+                export MBED_CLOUD_API_HOST=${MBED_CLOUD_API_HOST_OS2};
+                export MBED_CLOUD_API_KEY=${MBED_CLOUD_API_OS2};
+                echo 'environment variables swapped: ${CLOUD_VERSION}';
               fi
               echo "{\"api_key\":\"$MBED_CLOUD_API_KEY\", \"host\":\"$MBED_CLOUD_API_HOST\"}" > .mbed_cloud_config.json
               login="$(aws ecr get-login --no-include-email)"
@@ -203,6 +208,22 @@ jobs:
       PYVER: three
     machine: true
 
+  test_os2_2:
+    <<: *job_test_common
+    environment:
+      <<: *environ
+      CLOUD_VERSION: os2
+      PYVER: two
+    machine: true
+
+  test_os2_3:
+    <<: *job_test_common
+    environment:
+      <<: *environ
+      CLOUD_VERSION: os2
+      PYVER: three
+    machine: true
+
   deploy_beta:
     <<: *job_deploy_common
     environment:
@@ -228,14 +249,21 @@ workflows:
           requires:
             - build_2
             - test_integration_3
+      - test_integration_3:
+          requires:
+            - build_3
       - test_production_2:
           requires:
             - build_2
             - test_production_3
-      - test_integration_3:
+      - test_production_3:
           requires:
             - build_3
-      - test_production_3:
+      - test_os2_2:
+          requires:
+            - build_2
+            - test_os2_3
+      - test_os2_3:
           requires:
             - build_3
       - docs_build:
@@ -253,7 +281,7 @@ workflows:
       - release_beta:
           type: approval
           requires:
-            - test_integration_3
+            - test_os2_3
       - release_production:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ aliases:
               fi
               if [[ ${CLOUD_VERSION} == os2 ]]; then
                 export MBED_CLOUD_API_HOST=${MBED_CLOUD_API_HOST_OS2};
-                export MBED_CLOUD_API_KEY=${MBED_CLOUD_API_OS2};
+                export MBED_CLOUD_API_KEY=${MBED_CLOUD_API_KEY_OS2};
                 echo 'environment variables swapped: ${CLOUD_VERSION}';
               fi
               echo "{\"api_key\":\"$MBED_CLOUD_API_KEY\", \"host\":\"$MBED_CLOUD_API_HOST\"}" > .mbed_cloud_config.json


### PR DESCRIPTION
See build for diagram of current gating flow:
https://circleci.com/workflow-run/16070829-3328-41d9-8e07-36414110e2b5

Tests are run against all three environments on every push for every branch.

Specifically, `integration-lab` is deprecated to just being 'of note'. `os2` (what does that mean?!) is used for beta releases and gating merges to master (pending GitHub tweaks). `production` is used for gating production releases.