### PR TITLE
fix mappings (and tests) for notification channel fields

### DIFF
--- a/docs/news/1361.bugfix
+++ b/docs/news/1361.bugfix
@@ -1,0 +1,3 @@
+Previously, notifications for resource value changes would not be triggered.
+Resource value change subscriptions now use the correct routing keys. The SDK now provides the expected values for
+`device_id` and `resource_path` when notifying user code.

--- a/src/mbed_cloud/_version.py
+++ b/src/mbed_cloud/_version.py
@@ -35,7 +35,7 @@ API_MAJOR = '1'
 API_MINOR = '2'
 API_VERSION = '.'.join((API_MAJOR, API_MINOR))
 
-SDK_MAJOR = '8'
+SDK_MAJOR = '9'
 SDK_MINOR = ''
 LOCAL = None
 BETA = False

--- a/src/mbed_cloud/subscribe/channels/channel.py
+++ b/src/mbed_cloud/subscribe/channels/channel.py
@@ -128,8 +128,9 @@ class ChannelSubscription(object):
         """Notify this channel of inbound data"""
         for filter_function in self._filters:
             if not filter_function(data):
-                return
+                return False
         self._notify(data)
+        return True
 
     def __enter__(self):
         """Enter"""

--- a/src/mbed_cloud/subscribe/channels/channel.py
+++ b/src/mbed_cloud/subscribe/channels/channel.py
@@ -79,6 +79,7 @@ class ChannelSubscription(object):
         self._optional_filters = None
         self._route_keys = None
         self.add_filter_function(self._filter_optional_keys)
+        self.name = None
         super(ChannelSubscription, self).__init__()
 
     def get_routing_keys(self):
@@ -139,6 +140,10 @@ class ChannelSubscription(object):
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit"""
         return self.ensure_stopped()
+
+    def __repr__(self):
+        """String representation"""
+        return '<%s %s>' % (self.__class__.__name__, self.name or self._route_keys)
 
     def start(self):
         """Base method for starting the channel"""

--- a/src/mbed_cloud/subscribe/channels/resource_values.py
+++ b/src/mbed_cloud/subscribe/channels/resource_values.py
@@ -23,8 +23,6 @@ from mbed_cloud.subscribe.channels.channel import FirstValue
 
 from mbed_cloud.subscribe.subscribe import expand_dict_as_keys
 
-from mbed_cloud.connect.presubscription import Presubscription
-
 from mbed_cloud import tlv
 from mbed_cloud import utils
 

--- a/src/mbed_cloud/subscribe/channels/resource_values.py
+++ b/src/mbed_cloud/subscribe/channels/resource_values.py
@@ -113,10 +113,13 @@ class ResourceValues(ChannelSubscription):
 
     def _wildcard_filter(self, data):
         # custom local filtering based on wildcard string matches for each field
-        for k, list_v in self._local_filters.items():
-            value = data.get(k, '')
-            for v in list_v:
-                if self._wildcard_match(value, v):
+        for required_key, any_required_values in self._local_filters.items():
+            value = data.get(required_key)
+            if value is None:
+                # the filter key is missing from the data
+                return False
+            for required_value in any_required_values:
+                if self._wildcard_match(str(value), required_value):
                     break
             else:
                 # no match from optional list: this data is not a match

--- a/src/mbed_cloud/subscribe/subscribe.py
+++ b/src/mbed_cloud/subscribe/subscribe.py
@@ -154,9 +154,11 @@ class SubscriptionsManager(RoutingBase):
         return self.get_channel(subscription_channel, **observer_params).ensure_started().observer
     __call__ = subscribe
 
-    def _notify(self, item):
+    def _notify_single_item(self, item):
         """Route inbound items to individual channels"""
-        triggered_channels = []
+        # channels that this individual item has already triggered
+        # (dont want to trigger them again)
+        triggered_channels = set()
         for key_set in self.watch_keys:
             # only pluck keys if they exist
             plucked = {
@@ -166,7 +168,7 @@ class SubscriptionsManager(RoutingBase):
             route_keys = expand_dict_as_keys(plucked)
             for route in route_keys:
                 channels = self.get_route_items(route) or {}
-                LOG.debug('subscribed channels: %s', channels)
+                LOG.debug('route table match: %s -> %s', route, channels)
                 if not channels:
                     LOG.debug(
                         'no subscribers for message.\nkey %s\nroutes: %s',
@@ -174,13 +176,14 @@ class SubscriptionsManager(RoutingBase):
                         self._routes
                     )
                 for channel in channels:
-                    LOG.debug('routing dispatch: %s', item)
+                    if channel in triggered_channels:
+                        LOG.debug('skipping dispatch to %s', channel)
+                        continue
+                    LOG.debug('routing dispatch to %s: %s', channel, item)
                     try:
-                        channel.notify(item)
+                        channel.notify(item) and triggered_channels.add(channel)
                     except Exception:  # noqa
                         LOG.exception('Channel notification failed')
-                    else:
-                        triggered_channels.append(channel)
         return triggered_channels
 
     def notify(self, data):
@@ -188,12 +191,12 @@ class SubscriptionsManager(RoutingBase):
         triggered_channels = []
         for channel_name, items in data.items():
             for item in items or []:
-                LOG.debug('notified: %s', item)
+                LOG.debug('notify received: %s', item)
                 try:
                     # inject the channel name to the data (so channels can filter on it)
                     item = dict(item)
                     item['channel'] = channel_name
-                    triggered_channels.extend(self._notify(item))
+                    triggered_channels.extend(list(self._notify_single_item(item)))
                 except Exception:  # noqa
                     LOG.exception('Subscription notification failed')
         return triggered_channels

--- a/tests/unit/async/test_current_resource_value.py
+++ b/tests/unit/async/test_current_resource_value.py
@@ -12,7 +12,7 @@ import unittest
 
 class Test(BaseCase):
 
-    def test_wildcards(self):
+    def test_current_resource_value(self):
         device_id1 = 'ABCD_E'
         device_id2 = 'ABCD_F'
         resource_path = '/3/4/5'

--- a/tests/unit/async/test_resource_value_channel.py
+++ b/tests/unit/async/test_resource_value_channel.py
@@ -46,6 +46,7 @@ class Test(BaseCase):
         observer_b = subs.subscribe(channels.ResourceValues(device_id=device_id2, resource_path=5))
         observer_c = subs.subscribe(channels.ResourceValues(device_id='ABCD*', resource_path=5))
         observer_d = subs.subscribe(channels.ResourceValues(device_id=device_id1, custom_attr='x'))
+        observer_e = subs.subscribe(channels.ResourceValues(device_id='*'))
 
         subs.notify({
             channels.ChannelIdentifiers.notifications: [
@@ -55,6 +56,8 @@ class Test(BaseCase):
                 {'unexpected': 'extra', 'ep': device_id1, 'path': '2'},
                 # should trigger D (matches device id 1, custom attr)
                 {'ep': device_id1, 'custom_attr': 'x'},
+                # should not trigger anything
+                {'endpoint': device_id1, 'custom_attr': 'x'},
             ]
         })
 
@@ -62,6 +65,7 @@ class Test(BaseCase):
         self.assertEqual(1, observer_b.notify_count)
         self.assertEqual(1, observer_c.notify_count)
         self.assertEqual(2, observer_d.notify_count)
+        self.assertEqual(3, observer_e.notify_count)
 
     def test_payload(self):
         # subscription to wildcard value should be triggered when receiving specific value

--- a/tests/unit/async/test_resource_value_channel.py
+++ b/tests/unit/async/test_resource_value_channel.py
@@ -2,7 +2,6 @@ from mbed_cloud.subscribe import SubscriptionsManager
 from mbed_cloud.subscribe import channels
 from mbed_cloud.connect import ConnectAPI
 
-from types import SimpleNamespace
 from tests.common import BaseCase
 
 import mock


### PR DESCRIPTION
'endpoint-name' is used in presubs and was erroneously being used as the routing key

notifications actually send 'ep'

this fixes the routing keys, and also remaps 'ep' to 'device_id' before passing it to user code.