### PR TITLE
⭕️ 2039 Support test-runner schema for filtering

### DIFF
--- a/src/mbed_cloud/client/api_filter.py
+++ b/src/mbed_cloud/client/api_filter.py
@@ -136,7 +136,7 @@ class ApiFilter(object):
                 for sdk_operator, sdk_value in sdk_operator_value.items():
                     # The dictionary may contain multiple filters, process each one
                     api_value = _to_query_param(sdk_value)
-                    api_filter[api_field + "__" + sdk_operator] = api_value
+                    api_filter[api_field + "__" + sdk_operator.lstrip("$")] = api_value
             except AttributeError:
                 # Default to equality if a filter operator was not provided
                 api_value = _to_query_param(sdk_operator_value)

--- a/src/mbed_cloud/foundation/common/entity_base.py
+++ b/src/mbed_cloud/foundation/common/entity_base.py
@@ -24,14 +24,9 @@ class Entity(object):
 
     def __str__(self):
         """Human readable short format text"""
-        friendly = "?"
-        for name in (
-            getattr(self, f, None) for f in ["full_name", "name", "id"] + self._fieldnames
-        ):
-            if name is not None:
-                friendly = name
-                break
-        return "<%s %s>" % (self.__class__.__name__, friendly)
+        entity_id = getattr(self, "id", None)
+        entity_id = entity_id if entity_id else "?"
+        return "<%s %s>" % (self.__class__.__name__, entity_id)
 
     def __repr__(self):
         """Long format text (object might be re-instantiatable from this)"""
@@ -77,7 +72,7 @@ class Entity(object):
 
     def to_dict(self):
         """Return all fields as key-value pairs"""
-        return {field: getattr(self, field) for field in self._fieldnames}
+        return {field: getattr(self, "_" + field).value for field in self._fieldnames}
 
     def to_api(self):
         """Return all fields in API format"""

--- a/tests/unit/foundation/test_api_filter.py
+++ b/tests/unit/foundation/test_api_filter.py
@@ -181,3 +181,40 @@ class TestApiFilter(BaseCase):
 
         api_filter = ApiFilter(filter_definition, renames)
         self.assertEqual(expected_filter, api_filter.to_api())
+
+    def test_legacy_filter(self):
+        filter_definition = {
+            "created_at": {
+                "$gte": datetime(2019, 1, 1),
+                "$lte": date(2019, 12, 31),
+            },
+            "colour": {"$like": "purple"},
+            "integer": {"$neq": 42},
+            "float": {"$neq": 13.98},
+            "state": {"$in": ["OPEN", "CLOSED"]},
+            "city": {"$nin": ["Cambridge", "London"]},
+            "strange": {"$eq": {"hello": "world"}},
+            "done": False,
+            "firmware_checksum": None,
+        }
+        renames = {
+            "colour": "API_colour",
+            "state": "API_state",
+            "strange": "API_strange",
+            "firmware_checksum": "API_fw_csum",
+        }
+        expected_filter = {
+            "created_at__gte": "2019-01-01T00:00:00Z",
+            "created_at__lte": "2019-12-31",
+            "API_colour__like": "purple",
+
+            "integer__neq": 42,
+            "float__neq": 13.98,
+            "API_state__in": "OPEN,CLOSED",
+            "city__nin": "Cambridge,London",
+            "API_strange__eq": '{"hello": "world"}',
+            "done__eq": "false",
+            "API_fw_csum__eq": "null"}
+
+        api_filter = ApiFilter(filter_definition, renames)
+        self.assertEqual(expected_filter, api_filter.to_api())


### PR DESCRIPTION
- This has the side effect of supporting the legacy format for filtering