### PR TITLE
⭕️ 2306: Release tag now contains latest changelog

### DIFF
--- a/docs/news/2306.misc
+++ b/docs/news/2306.misc
@@ -1,0 +1,1 @@
+Changed order of calls in tag_and_release so that changelog is generated before release is tagged.

--- a/docs/news/2306.misc
+++ b/docs/news/2306.misc
@@ -1,1 +1,1 @@
-New releases now relfect the most up-to-date changelogs.
+Pelion reference documentation for the SDK will now contain the most recent changelog and version information.

--- a/docs/news/2306.misc
+++ b/docs/news/2306.misc
@@ -1,1 +1,1 @@
-Changed order of calls in tag_and_release so that changelog is generated before release is tagged.
+New releases now relfect the most up-to-date changelogs.

--- a/scripts/tag_and_release.py
+++ b/scripts/tag_and_release.py
@@ -77,13 +77,6 @@ def main(mode):
     subprocess.check_call(['git', 'branch', '--set-upstream-to', branch_spec])
     subprocess.check_call(['git', 'fetch', '--tags', '--force'])
 
-    # tags
-    subprocess.check_call(['git', 'tag', '-a', version, '-m', 'release %s' % version])
-    subprocess.check_call(['git', 'tag', '-f', 'latest'])
-    if mode == release_target_map['prod']:
-        print('git - pushing %s tags' % mode.name)
-        subprocess.check_call(['git', 'push', '-f', 'origin', '--tags'])
-
     print('git - add changes')
     subprocess.check_call(['git', 'add', 'src/mbed_cloud/_version.py'])
     subprocess.check_call(['git', 'add', 'CHANGELOG.rst'])
@@ -94,6 +87,13 @@ def main(mode):
     if mode == release_target_map['prod']:
         print('git - pushing %s changelog commit' % mode.name)
         subprocess.check_call(['git', 'push', 'origin'])
+
+    # tags
+    subprocess.check_call(['git', 'tag', '-a', version, '-m', 'release %s' % version])
+    subprocess.check_call(['git', 'tag', '-f', 'latest'])
+    if mode == release_target_map['prod']:
+        print('git - pushing %s tags' % mode.name)
+        subprocess.check_call(['git', 'push', '-f', 'origin', '--tags'])
 
     print('pypi - uploading')
     subprocess.check_call(['python', '-m', 'twine', 'upload', mode.bundle])


### PR DESCRIPTION
- Changed the order of calls in the tag_and_release build script to ensure that Towncrier is run before a GitHub tag is created, so that the public documentation now includes the most recent release notes.