### PR TITLE
🔧 Properly handle openssl version > 1.0.X

### DIFF
--- a/docs/news/20190913.bugfix
+++ b/docs/news/20190913.bugfix
@@ -1,0 +1,1 @@
+Handled the case when the openssl major version is greater than 1 and the minor version is greater than 0

--- a/src/mbed_cloud/sdk/sdk.py
+++ b/src/mbed_cloud/sdk/sdk.py
@@ -107,7 +107,7 @@ def check_openssl_version():
     minor = int(match.group(3))
     patch = int(match.group(4))
 
-    if major >= 1 and minor >= 0 and patch >= 2:
+    if (major, minor, patch) >= (1, 0, 2):
         return  # all ok
 
     warnings.warn("""


### PR DESCRIPTION
Handle the case when the major version is greater than 1 and the minor
version is greater than 0.  For example, my current host uses openssl
1.1.1.