### PR TITLE
🔧 Disabled trust for insecure environment

### DIFF
--- a/docs/news/20190912.bugfix
+++ b/docs/news/20190912.bugfix
@@ -1,0 +1,1 @@
+Disabled requests lib trust for insecure environment

--- a/src/mbed_cloud/client/client.py
+++ b/src/mbed_cloud/client/client.py
@@ -37,6 +37,7 @@ class Client(object):
         """
         self.config = config
         self.session = requests.Session()
+        self.session.trust_env = False
         self.session.headers.update(
             {
                 "Authorization": "Bearer %s" % self.config.api_key,


### PR DESCRIPTION
requests does a bunch of weird things, [including reading auth info from your ~/.netrc file](https://github.com/psf/requests/issues/2773).  Disable that so our authorization header doesn't get stomped.